### PR TITLE
Fix null pointer exception in ProductPageController

### DIFF
--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/ProductPageController.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/ProductPageController.cs
@@ -35,6 +35,11 @@ namespace SDL.ECommerce.DXA.Controllers
         /// <returns></returns>
         public ActionResult ProductPage(string productUrl)
         {
+            if (string.IsNullOrEmpty(productUrl))
+            {
+                return NotFound();
+            }
+
             var pathTokens = productUrl.Split( new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             string productSeoId;
             string productId;


### PR DESCRIPTION
Fixed null pointer exception. The product page throws errors if no product url is passed.