### PR TITLE
add localization id to Flyout cache key

### DIFF
--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/BaseEComWidgetController.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/BaseEComWidgetController.cs
@@ -8,6 +8,7 @@ using System.Web.Mvc;
 using SDL.ECommerce.DXA.Models;
 using SDL.ECommerce.Api;
 using SDL.ECommerce.Api.Model;
+using Sdl.Web.Mvc.Configuration;
 using System.Runtime.Caching;
 
 namespace SDL.ECommerce.DXA.Controller
@@ -158,7 +159,7 @@ namespace SDL.ECommerce.DXA.Controller
                 widget.CategoryReference.Category = ResolveCategory(widget.CategoryReference);
                 if (widget.CategoryReference.Category != null)
                 {
-                    var cachedData = this.GetCachedFlyoutData(widget.CategoryReference.Category.Id);
+                    var cachedData = this.GetCachedFlyoutData(widget.CategoryReference.Category.Id, WebRequestContext.Localization.LocalizationId);
                     if (cachedData == null)
                     {
                         var queryResult = ECommerceContext.Client.QueryService.Query(
@@ -173,7 +174,7 @@ namespace SDL.ECommerce.DXA.Controller
                             FacetGroups = queryResult.FacetGroups.ToList(),
                             Promotions = queryResult.Promotions.ToList()
                         };
-                        this.CacheFlyoutData(widget.CategoryReference.Category.Id, cachedData);
+                        this.CacheFlyoutData(widget.CategoryReference.Category.Id, WebRequestContext.Localization.LocalizationId, cachedData);
                     }
                     widget.FacetGroups = cachedData.FacetGroups;
                     widget.RelatedPromotions = cachedData.Promotions;
@@ -452,16 +453,16 @@ namespace SDL.ECommerce.DXA.Controller
 
         }
 
-        private FlyoutData GetCachedFlyoutData(string categoryId)
+        private FlyoutData GetCachedFlyoutData(string categoryId, string LocalizationId)
         {
-            return this.flyoutCache[categoryId] as FlyoutData;
+            return this.flyoutCache[string.Concat(categoryId, "-", LocalizationId)] as FlyoutData;
         }
 
-        private void CacheFlyoutData(string categoryId, FlyoutData flyoutData)
+        private void CacheFlyoutData(string categoryId, string LocalizationId, FlyoutData flyoutData)
         {
             // Default cache flyout data in 1 hour. TODO: Have this configurable
             //
-            this.flyoutCache.Add(categoryId, flyoutData, DateTimeOffset.Now.AddHours(1.0));
+            this.flyoutCache.Add(string.Concat(categoryId, "-", LocalizationId), flyoutData, DateTimeOffset.Now.AddHours(1.0));
         }
 
         private ObjectCache flyoutCache = MemoryCache.Default;


### PR DESCRIPTION
The Flyout menu is cached which is great! But, the cache key does not take localization into account, so all publications get the same flyout menu.