### PR TITLE
Add TotalCount in ListerNavigationData contract

### DIFF
--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/BaseEComWidgetController.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/BaseEComWidgetController.cs
@@ -24,13 +24,16 @@ namespace SDL.ECommerce.DXA.Controllers
         //
         private string _clientType =  WebConfigurationManager.AppSettings["ecommerce-service-client-type"] ?? "odata";
 
+        private IECommerceClient _eCommerceClient;
+
         protected BaseEComWidgetController()
         {
             LinkResolver = DependencyFactory.Current.Resolve<IECommerceLinkResolver>();
+            _eCommerceClient = DependencyFactory.Current.Resolve<IECommerceClient>();
         }
 
         protected IECommerceLinkResolver LinkResolver { get; }
-        
+
         /// <summary>
         /// Product Detail
         /// </summary>
@@ -102,7 +105,7 @@ namespace SDL.ECommerce.DXA.Controllers
             if ( widget.CategoryReference != null )
             {
                 var category = ResolveCategory(widget.CategoryReference);
-                queryResult = ECommerceContext.Client.QueryService.Query(new Api.Model.Query { Category = category });
+                queryResult = _eCommerceClient.QueryService.Query(new Api.Model.Query { Category = category });
             }
             else
             {
@@ -359,15 +362,15 @@ namespace SDL.ECommerce.DXA.Controllers
             ICategory category = null;
             if ( categoryReference.CategoryPath != null )
             {
-                category = ECommerceContext.Client.CategoryService.GetCategoryByPath(categoryReference.CategoryPath);
+                category = _eCommerceClient.CategoryService.GetCategoryByPath(categoryReference.CategoryPath);
             }
             else if ( categoryReference.CategoryId != null )
             {
-                category = ECommerceContext.Client.CategoryService.GetCategoryById(categoryReference.CategoryId);
+                category = _eCommerceClient.CategoryService.GetCategoryById(categoryReference.CategoryId);
             }
             else if ( categoryReference.CategoryRef != null )
             {
-                category = ECommerceContext.Client.CategoryService.GetCategoryById(categoryReference.CategoryRef.ExternalId);
+                category = _eCommerceClient.CategoryService.GetCategoryById(categoryReference.CategoryRef.ExternalId);
             }
             return category;
         }
@@ -423,7 +426,10 @@ namespace SDL.ECommerce.DXA.Controllers
             int startIndex = result.StartIndex;
             int currentSet = result.CurrentSet;
 
-            lister.NavigationData = new ListerNavigationData();
+            lister.NavigationData = new ListerNavigationData 
+            {
+                TotalCount = totalCount
+            };
 
             int viewSets = 1;
             if (totalCount > viewSize)

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Models/ListerNavigationData.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Models/ListerNavigationData.cs
@@ -12,5 +12,6 @@
         public string PreviousUrl { get; set; }
         public string FirstUrl { get; set; }
         public string LastUrl { get; set; }
+        public int TotalCount { get; set; }
     }
 }

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Dxa/Controllers/BaseEComWidgetController_Test.cs
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Dxa/Controllers/BaseEComWidgetController_Test.cs
@@ -1,0 +1,49 @@
+using System.Web.Mvc;
+using NSubstitute;
+using Ploeh.AutoFixture;
+using SDL.ECommerce.Api;
+using SDL.ECommerce.Api.Model;
+using SDL.ECommerce.Api.Service;
+using SDL.ECommerce.DXA.Models;
+using SDL.ECommerce.UnitTests;
+using SDL.ECommerce.UnitTests.Dxa.Fakes;
+using Xunit;
+
+public class BaseEComWidgetController_Test : Test<FakeBaseEcomWidgetController>
+{
+    [Fact]
+    public void WhenInvokingProductLister_ThenTotalCountShouldBeMappedToNavigationData()
+    {
+        //Arrange
+        var expectedTotalCount = Fixture.Create<int>();
+        var expectedViewSize = 40;
+
+        var queryService = Fixture.Freeze<IProductQueryService>();
+        queryService.Query(Arg.Any<Query>()).TotalCount.Returns(expectedTotalCount);
+        queryService.Query(Arg.Any<Query>()).ViewSize.Returns(expectedViewSize);
+
+        var categoryService = Fixture.Freeze<IProductCategoryService>();
+        categoryService.GetCategoryByPath(Arg.Any<string>()).Returns((ICategory)null);
+
+        var eCommerceClient = new FakeECommerceClient
+        {
+            CategoryService = categoryService,
+            QueryService = queryService
+        };
+        
+        Fixture.Register<IECommerceClient>(() => eCommerceClient);
+
+        var entity = Fixture.Create<ProductListerWidget>();
+
+        //Act
+        ViewResult result;
+        using (new DependencyTestProvider(Fixture))
+        {
+            result = SystemUnderTest.ProductLister(entity) as ViewResult;
+        }
+
+        //Assert
+        var model = (ProductListerWidget)result?.Model;
+        Assert.Equal(model?.NavigationData.TotalCount, expectedTotalCount);
+    }
+}

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Dxa/Fakes/FakeBaseEcomWidgetController.cs
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Dxa/Fakes/FakeBaseEcomWidgetController.cs
@@ -1,0 +1,9 @@
+﻿using SDL.ECommerce.DXA.Controllers;
+
+namespace SDL.ECommerce.UnitTests.Dxa.Fakes
+{
+    public class FakeBaseEcomWidgetController : BaseEComWidgetController
+    {
+    
+    }
+}

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Dxa/Fakes/FakeECommerceClient.cs
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Dxa/Fakes/FakeECommerceClient.cs
@@ -1,0 +1,18 @@
+﻿using SDL.ECommerce.Api;
+using SDL.ECommerce.Api.Service;
+
+namespace SDL.ECommerce.UnitTests.Dxa.Fakes
+{
+    public class FakeECommerceClient : IECommerceClient
+    {
+        public IProductCategoryService CategoryService { get; set; }
+
+        public IProductQueryService QueryService { get; set; }
+
+        public IProductDetailService DetailService { get; set; }
+
+        public ICartService CartService { get; set; }
+
+        public IEditService EditService { get; set; }
+    }
+}

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/SDL.ECommerce.UnitTests.csproj
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/SDL.ECommerce.UnitTests.csproj
@@ -186,7 +186,10 @@
     <Compile Include="Customizations\Sdl\LocalizationCustomization.cs" />
     <Compile Include="Customizations\Sdl\PageModelCustomization.cs" />
     <Compile Include="DependencyTestProvider.cs" />
+    <Compile Include="Dxa\Controllers\BaseEComWidgetController_Test.cs" />
     <Compile Include="Dxa\Controllers\CategoryPageController_Test.cs" />
+    <Compile Include="Dxa\Fakes\FakeBaseEcomWidgetController.cs" />
+    <Compile Include="Dxa\Fakes\FakeECommerceClient.cs" />
     <Compile Include="Dxa\Controllers\ProductPageController_Test.cs" />
     <Compile Include="Dxa\Factories\DependencyFactory_Test.cs" />
     <Compile Include="Dxa\Providers\DependencyResolverProvider_Test.cs" />


### PR DESCRIPTION
Added TotalCount in ListerNavigationData to be able to know total hits for the search. Ex. show total products.