### PR TITLE
Extracted sanitizer to formatting project.

### DIFF
--- a/dxa.net/NuGet/Sdl.ECommerce.Dxa.nuspec
+++ b/dxa.net/NuGet/Sdl.ECommerce.Dxa.nuspec
@@ -19,6 +19,7 @@
   </metadata>
   <files>
 	<file src="SDL.ECommerce.Dxa\bin\SDL.ECommerce.Dxa.dll" target="lib\net452" />
+	<file src="SDL.ECommerce.Dxa\bin\SDL.ECommerce.Formatting.dll" target="lib\net452" />
 	<file src="SDL.ECommerce.Dxa\bin\SDL.ECommerce.Api.dll" target="lib\net452" />
 	<file src="SDL.ECommerce.Dxa\bin\SDL.ECommerce.OData.dll" target="lib\net452" />
 	<file src="SDL.ECommerce.Dxa\bin\SDL.ECommerce.Rest.dll" target="lib\net452" />

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/DXALinkResolver.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/DXALinkResolver.cs
@@ -3,12 +3,11 @@ using System;
 using System.Collections.Generic;
 using SDL.ECommerce.Api.Model;
 using System.Text;
-using SDL.ECommerce.DXA.Servants;
+using System.Linq;
+using SDL.ECommerce.Formatting.Servants;
 
 namespace SDL.ECommerce.DXA
 {
-    using System.Linq;
-
     public class DXALinkResolver : IECommerceLinkResolver
     {
         private readonly ISanitizerServant _sanitizerServant;

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/SDL.ECommerce.DXA.csproj
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/SDL.ECommerce.DXA.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
@@ -244,12 +244,8 @@
     <Compile Include="Servants\IHttpContextServant.cs" />
     <Compile Include="Servants\IPageModelServant.cs" />
     <Compile Include="Servants\IPathServant.cs" />
-    <Compile Include="Servants\ISanitizerConfiguration.cs" />
-    <Compile Include="Servants\ISanitizerServant.cs" />
     <Compile Include="Servants\PageModelServant.cs" />
     <Compile Include="Servants\PathServant.cs" />
-    <Compile Include="Servants\SanitizerConfiguration.cs" />
-    <Compile Include="Servants\SanitizerServant.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config">
@@ -267,6 +263,10 @@
     <ProjectReference Include="..\SDL.ECommerce.Api\SDL.ECommerce.Api.csproj">
       <Project>{1030d0f7-9334-4864-b495-540e3ad7928c}</Project>
       <Name>SDL.ECommerce.Api</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SDL.ECommerce.Formatting\SDL.ECommerce.Formatting.csproj">
+      <Project>{e2beacd6-4a49-43b4-8e84-2dc4df9a4690}</Project>
+      <Name>SDL.ECommerce.Formatting</Name>
     </ProjectReference>
     <ProjectReference Include="..\SDL.ECommerce.OData\SDL.ECommerce.OData.csproj">
       <Project>{f5434b12-5f20-48df-8b17-a6c2a1345ba9}</Project>

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Properties/AssemblyInfo.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SDL.ECommerce.Formatting")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SDL.ECommerce.Formatting")]
+[assembly: AssemblyCopyright("Copyright © 2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e2beacd6-4a49-43b4-8e84-2dc4df9a4690")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/SDL.ECommerce.Formatting.csproj
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/SDL.ECommerce.Formatting.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E2BEACD6-4A49-43B4-8E84-2DC4DF9A4690}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SDL.ECommerce.Formatting</RootNamespace>
+    <AssemblyName>SDL.ECommerce.Formatting</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Servants\ISanitizerConfiguration.cs" />
+    <Compile Include="Servants\ISanitizerServant.cs" />
+    <Compile Include="Servants\SanitizerConfiguration.cs" />
+    <Compile Include="Servants\SanitizerServant.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/ISanitizerConfiguration.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/ISanitizerConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace SDL.ECommerce.DXA.Servants
+﻿namespace SDL.ECommerce.Formatting.Servants
 {
     using System.Collections.Generic;
 

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/ISanitizerServant.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/ISanitizerServant.cs
@@ -1,4 +1,4 @@
-﻿namespace SDL.ECommerce.DXA.Servants
+﻿namespace SDL.ECommerce.Formatting.Servants
 {
     public interface ISanitizerServant
     {

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/SanitizerConfiguration.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/SanitizerConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace SDL.ECommerce.DXA.Servants
+﻿namespace SDL.ECommerce.Formatting.Servants
 {
     using System.Collections.Generic;
 

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/SanitizerServant.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.Formatting/Servants/SanitizerServant.cs
@@ -1,4 +1,4 @@
-﻿namespace SDL.ECommerce.DXA.Servants
+﻿namespace SDL.ECommerce.Formatting.Servants
 {
     using System;
     using System.Collections.Generic;

--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.sln
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
@@ -20,6 +20,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SDL.ECommerce.IntegrationTests", "Tests\SDL.ECommerce.IntegrationTests\SDL.ECommerce.IntegrationTests.csproj", "{5EB69A43-7467-4A7A-8CFE-D23274B56B07}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SDL.ECommerce.Rest", "SDL.ECommerce.Rest\SDL.ECommerce.Rest.csproj", "{055151C2-713C-49DE-85A3-1E073E88CB94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SDL.ECommerce.Formatting", "SDL.ECommerce.Formatting\SDL.ECommerce.Formatting.csproj", "{E2BEACD6-4A49-43B4-8E84-2DC4DF9A4690}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,10 @@ Global
 		{055151C2-713C-49DE-85A3-1E073E88CB94}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{055151C2-713C-49DE-85A3-1E073E88CB94}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{055151C2-713C-49DE-85A3-1E073E88CB94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2BEACD6-4A49-43B4-8E84-2DC4DF9A4690}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2BEACD6-4A49-43B4-8E84-2DC4DF9A4690}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2BEACD6-4A49-43B4-8E84-2DC4DF9A4690}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2BEACD6-4A49-43B4-8E84-2DC4DF9A4690}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -66,5 +72,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{2819AEB8-2277-4E43-96B9-A20A3BFEE941} = {11F3867C-0A6E-401C-BDE1-6FAD162D609F}
 		{5EB69A43-7467-4A7A-8CFE-D23274B56B07} = {11F3867C-0A6E-401C-BDE1-6FAD162D609F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1048CAD0-53EA-435F-9535-1D3FE57BCC6C}
 	EndGlobalSection
 EndGlobal

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Formatting/Servants/SanitizerConfiguration_Test.cs
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Formatting/Servants/SanitizerConfiguration_Test.cs
@@ -1,8 +1,8 @@
-﻿namespace SDL.ECommerce.UnitTests.Dxa.Servants
+﻿namespace SDL.ECommerce.UnitTests.Formatting.Servants
 {
-    using DXA.Servants;
-    using Xunit;
     using System.Collections.Generic;
+    using ECommerce.Formatting.Servants;
+    using Xunit;
 
     public class SanitizerConfiguration_Test
     {

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Formatting/Servants/SanitizerServant_Test.cs
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/Formatting/Servants/SanitizerServant_Test.cs
@@ -1,8 +1,8 @@
-﻿namespace SDL.ECommerce.UnitTests.Dxa.Servants
+﻿namespace SDL.ECommerce.UnitTests.Formatting.Servants
 {
-    using DXA.Servants;
-    using Xunit;
     using System;
+    using ECommerce.Formatting.Servants;
+    using Xunit;
 
     public class SanitizerServantTest
     {

--- a/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/SDL.ECommerce.UnitTests.csproj
+++ b/dxa.net/ecommerce-framework-dotnet/Tests/SDL.ECommerce.UnitTests/SDL.ECommerce.UnitTests.csproj
@@ -225,9 +225,9 @@
     <Compile Include="Dxa\Servants\HttpContextServant_Test.cs" />
     <Compile Include="Dxa\Servants\PageModelServant_Test.cs" />
     <Compile Include="Dxa\Servants\PathServant_Test.cs" />
-    <Compile Include="Dxa\Servants\SanitizerConfiguration_Test.cs" />
-    <Compile Include="Dxa\Servants\SanitizerServant_Test.cs" />
     <Compile Include="FixtureExtensions.cs" />
+    <Compile Include="Formatting\Servants\SanitizerConfiguration_Test.cs" />
+    <Compile Include="Formatting\Servants\SanitizerServant_Test.cs" />
     <Compile Include="MultipleAssertTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Test.cs" />
@@ -241,6 +241,10 @@
     <ProjectReference Include="..\..\SDL.ECommerce.DXA\SDL.ECommerce.DXA.csproj">
       <Project>{1d5a79d3-8870-410d-99fd-5d54601e19b5}</Project>
       <Name>SDL.ECommerce.DXA</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\SDL.ECommerce.Formatting\SDL.ECommerce.Formatting.csproj">
+      <Project>{e2beacd6-4a49-43b4-8e84-2dc4df9a4690}</Project>
+      <Name>SDL.ECommerce.Formatting</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The sanitizer, and maybe other things later on, can be reused for other SDL segments (e.g. CM, ECL, TBB) or other integrations. We can maybe also extract the formatting project to its own NuGet package and reference that from the DXA package just like example views and navigation.