### PR TITLE
Product Cache and fix double Enrich of NotFound

### DIFF
--- a/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/AbstractECommercePageController.cs
+++ b/dxa.net/ecommerce-framework-dotnet/SDL.ECommerce.DXA/Controllers/AbstractECommercePageController.cs
@@ -134,7 +134,6 @@ namespace SDL.ECommerce.DXA.Controllers
                 PageModel pageModel = PageModelServant.GetNotFoundPageModel(ContentProvider);
                 WebRequestContext.PageModel = pageModel;
                 SetupViewData(pageModel);
-                ViewModel model = EnrichModel(pageModel) ?? pageModel;
                 Response.StatusCode = 404;
                 return View(pageModel);
             }

--- a/ecl/ecommerce-ecl-framework/ecommerce-ecl-framework/CachedProduct.cs
+++ b/ecl/ecommerce-ecl-framework/ecommerce-ecl-framework/CachedProduct.cs
@@ -14,5 +14,6 @@ namespace SDL.ECommerce.Ecl
     {
         public int Requested { get; set; }
         public Product Product { get; set; }
+        public bool HasFullData { get; set; }
     }
 }

--- a/ecl/fredhopper-ecl-provider/fredhopper-ecl-provider/FredhopperEclProvider.cs
+++ b/ecl/fredhopper-ecl-provider/fredhopper-ecl-provider/FredhopperEclProvider.cs
@@ -5,7 +5,7 @@ using Tridion.ExternalContentLibrary.V2;
 
 namespace SDL.Fredhopper.Ecl
 {
-    [AddIn("Fredhopper-ECL-Provider", Version = "1.2.0.6")]
+    [AddIn("Fredhopper-ECL-Provider", Version = "1.2.0.7")]
     public class FredhopperEclProvider : EclProvider
     {
 

--- a/ecl/fredhopper-ecl-provider/fredhopper-ecl-provider/Models.cs
+++ b/ecl/fredhopper-ecl-provider/fredhopper-ecl-provider/Models.cs
@@ -197,7 +197,6 @@ namespace SDL.Fredhopper.Ecl
         {
             string fhAttribute;
             this.modelMappings.TryGetValue(name, out fhAttribute);
-            string fhStringValue = null;
             if ( fhAttribute != null )
             {
                 object fhValue;
@@ -220,7 +219,7 @@ namespace SDL.Fredhopper.Ecl
                     }
                     if ( value != null )
                     {
-                        return usePresentationValue == true ? value.PresentationValue : value.Value;
+                        return usePresentationValue ? value.PresentationValue : value.Value;
                     }
                 }           
             }


### PR DESCRIPTION
Added a cache for full product data in order to speed up publish step, which also speeds up load times of XPM.
When calling NotFound in PageController, it enriched the model twice.