### PR TITLE
Handle load categories when there is no filters

### DIFF
--- a/ecl/fredhopper-ecl-provider/fredhopper-ecl-provider/FredhopperProductCatalog.cs
+++ b/ecl/fredhopper-ecl-provider/fredhopper-ecl-provider/FredhopperProductCatalog.cs
@@ -216,7 +216,7 @@ namespace SDL.Fredhopper.Ecl
             universe universe = this.GetUniverse(fhPage);
 
             var facetmap = universe.facetmap[0];
-            var filters = facetmap.filter;
+            var filters = facetmap.filter ?? new filter[]{};
 
             IList<Category> newCategoryList = new List<Category>();
 


### PR DESCRIPTION
We have got an issue when a category has no products. Then the Fredhopper response comes with an empty facetmap.

`<facetmap universe="catalog01"/>`